### PR TITLE
Add haunting recipes + small things

### DIFF
--- a/config.sk
+++ b/config.sk
@@ -403,7 +403,7 @@ databases:
 		
 		# ==== Settings that should not be changed ====
 		
-version: 2.11.1
+version: 2.11.2
 # DO NOT CHANGE THIS VALUE MANUALLY!
 # This saves for which version of Skript this configuration was written for.
 # If it does not match the version of the .jar file then the config will be updated automatically.

--- a/datapacks/TurtleRealm/data/minecraft/advancement/adventure/root.json
+++ b/datapacks/TurtleRealm/data/minecraft/advancement/adventure/root.json
@@ -9,7 +9,7 @@
   },
   "display": {
     "announce_to_chat": false,
-    "background": "minecraft:textures/gui/advancements/backgrounds/adventure.png",
+    "background": "minecraft:gui/advancements/backgrounds/adventure",
     "description": {
       "text": "Explore the wonders of this world"
     },

--- a/datapacks/TurtleRealm/data/turtle/advancement/combat/root.json
+++ b/datapacks/TurtleRealm/data/turtle/advancement/combat/root.json
@@ -9,7 +9,7 @@
   },
   "display": {
     "announce_to_chat": false,
-    "background": "turtle:textures/gui/advancements/backgrounds/combat.png",
+    "background": "turtle:gui/advancements/backgrounds/combat",
     "description": {
       "translate": "Sharpen your skills"
     },

--- a/datapacks/TurtleRealm/data/turtle/jukebox_song/portal_radio.json
+++ b/datapacks/TurtleRealm/data/turtle/jukebox_song/portal_radio.json
@@ -1,0 +1,10 @@
+{
+  "comparator_output": 1,
+  "description": {
+    "translate": "Kelly Bailey - Still Alive (Radio Mix)"
+  },
+  "length_in_seconds": 46.0,
+  "sound_event": {
+    "sound_id": "turtle:music_disc.portal_radio"
+  }
+}

--- a/scripts/items/custom/magnifying_glass.sk
+++ b/scripts/items/custom/magnifying_glass.sk
@@ -31,7 +31,6 @@ on right click:
     set {_e} to (clicked entity)
     set {_b} to (clicked block)
     if {_e} is set:
-        cancel event
         # name
         set {_real_name} to (translate component from (translation key of {_e}))
         set {_custom_name} to (custom name of {_e})
@@ -58,23 +57,24 @@ on right click:
             set {_owner_component} to playerComponent({_owner}) if {_owner} is a player else (name of {_owner})
             add merge components (text component from "   §6👑 §7Owner: ") and {_owner_component} to {_info::*}
         # villagers
-        set {_villagerLevel} to (villager level of {_e})
-        if {_villagerLevel} is set:
-            add (merge components ("   §a👤 §7Level: ",(translate component from "merchant.level.%{_villagerLevel}%"))) to {_info::*}
-        set {_reputations} to (try event-entity.getReputations())
-        if {_reputations} is set:
-            set {_cured} to whether ((...{_reputations}.values() where [input.getReputation(ReputationType.MAJOR_POSITIVE)]) is set)
-            set {_cured} to "Yes" if ({_cured} is true) else "No"
-            add "   §e🍎 §7Cured: §f%{_cured}%" to {_info::*}
-        set {_workstation} to (work station of {_e})
-        if {_workstation} is set:
-            set {_workstationName} to (translate component from {_workstation})
-            set {_x} to floor(x-coord of {_workstation})
-            set {_y} to floor(y-coord of {_workstation})
-            set {_z} to floor(z-coord of {_workstation})
-            set {_workstationPos} to (text component from "§3%{_x}%§7,§3%{_y}%§7,§3%{_z}%")
-            set (click event of {_workstationPos}) to (click event to run command "/turtle:lookat %{_x}% %{_y}% %{_z}%")
-            add (merge components ("   §7🏠 §fWorkstation: ",{_workstationName}," at ",{_workstationPos})) to {_info::*}
+        if ({_e} is a villager):
+            set {_villagerLevel} to (villager level of {_e})
+            if {_villagerLevel} is set:
+                add (merge components ("   §a👤 §7Level: ",(translate component from "merchant.level.%{_villagerLevel}%"))) to {_info::*}
+            set {_reputations} to (try event-entity.getReputations())
+            if {_reputations} is set:
+                set {_cured} to whether ((...{_reputations}.values() where [input.getReputation(ReputationType.MAJOR_POSITIVE)]) is set)
+                set {_cured} to "Yes" if ({_cured} is true) else "No"
+                add "   §e🍎 §7Cured: §f%{_cured}%" to {_info::*}
+            set {_workstation} to (work station of {_e})
+            if {_workstation} is set:
+                set {_workstationName} to (translate component from {_workstation})
+                set {_x} to floor(x-coord of {_workstation})
+                set {_y} to floor(y-coord of {_workstation})
+                set {_z} to floor(z-coord of {_workstation})
+                set {_workstationPos} to (text component from "§3%{_x}%§7,§3%{_y}%§7,§3%{_z}%")
+                set (click event of {_workstationPos}) to (click event to run command "/turtle:lookat %{_x}% %{_y}% %{_z}%")
+                add (merge components ("   §7🏠 §fWorkstation: ",{_workstationName}," at ",{_workstationPos})) to {_info::*}
         # wandering trader despawn
         set {_despawnDelay} to (try {_e}.getDespawnDelay())
         if {_despawnDelay} is set:
@@ -91,9 +91,10 @@ on right click:
         # VIBING
         if ({_e} is dancing):
             add "   §d🎶 §cV§6I§eB§aI§bN§dG" to {_info::*}
+        if (size of {_info::*}) <= 1:
+            exit trigger
         send components {_info::*} to player
     else if {_b} is set:
-        cancel event
         # name
         set {_name} to (translate component of {_b})
         set {_customName} to (name of block within {_b})
@@ -120,9 +121,12 @@ on right click:
                     add "   §3🔻 §7Whitelist Filter: §f%{_joinNames}%" to {_info::*}
             else:
                 add "   §3🔻 §7No Filter" to {_info::*}
+        if (size of {_info::*}) <= 1:
+            exit trigger
         send components {_info::*} to player
     else:
         exit trigger
+    cancel event
     play sound "minecraft:entity.illusioner.prepare_mirror" in player category at player to player
     player.setCooldown(1 of player's tool, floor(20*(float tag "minecraft:use_cooldown;seconds" of nbt of player's tool)))
     make player swing their hand

--- a/scripts/items/vanilla/discs.sk
+++ b/scripts/items/vanilla/discs.sk
@@ -9,6 +9,7 @@ when ready to register custom items:
     set (custom item "turtle:music_disc_megalovania") to (music disc cat with nbt from "{""minecraft:item_model"":""turtle:music_disc_megalovania"",""minecraft:jukebox_playable"":""turtle:megalovania""}")
     set (custom item "turtle:music_disc_fly_octo_fly") to (music disc cat with nbt from "{""minecraft:item_model"":""turtle:music_disc_fly_octo_fly"",""minecraft:rarity"":""rare"",""minecraft:jukebox_playable"":""turtle:fly_octo_fly""}")
     set (custom item "turtle:music_disc_milky_ways") to (music disc cat with nbt from "{""minecraft:item_model"":""turtle:music_disc_milky_ways"",""minecraft:rarity"":""epic"",""minecraft:jukebox_playable"":""turtle:milky_ways""}")
+    set (custom item "minecraft:cake") to (cake with nbt from "{""minecraft:jukebox_playable"":""turtle:portal_radio"",""minecraft:tooltip_display"":{hidden_components:[""jukebox_playable""]}}")
 
 # disc recipes
 when ready to load recipes:

--- a/scripts/processing/haunting.sk
+++ b/scripts/processing/haunting.sk
@@ -1,0 +1,131 @@
+
+import:
+    org.bukkit.event.block.CampfireStartEvent
+
+# dont allow haunting recipes in normal campfires
+on CampfireStartEvent:
+    event.getRecipe().getGroup() is "haunting"
+    event.getBlock() is a campfire
+    event.setTotalCookTime(2147483647)
+
+when ready to load recipes:
+    register campfire recipe:
+        id: "turtle:haunt_lapis"
+        input: lapis lazuli
+        result: prismarine shard
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_red_mushroom"
+        input: red mushroom
+        result: crimson fungus
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_brown_mushroom"
+        input: brown mushroom
+        result: warped fungus
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_potato"
+        input: potato
+        result: poisonous potato
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_brick"
+        input: brick
+        result: nether brick
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_campfire"
+        input: campfire
+        result: soul campfire
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_lantern"
+        input: lantern
+        result: soul lantern
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_torch"
+        input: torch
+        result: soul torch
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_dirt"
+        input: material choice of (tag values of block tag "dirt")
+        result: soul soil
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_sand"
+        input: material choice of (sand, red sand)
+        result: soul sand
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_sweet_berries"
+        input: sweet berries
+        result: glow berries
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_cobblestone"
+        input: material choice of (cobblestone, mossy cobblestone)
+        result: blackstone
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_ink_sac"
+        input: ink sac
+        result: glow ink sac
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_stone"
+        input: stone
+        result: infested stone
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_cobblestone"
+        input: cobblestone
+        result: infested cobblestone
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_stone_bricks"
+        input: stone bricks
+        result: infested stone bricks
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_mossy_stone_bricks"
+        input: mossy stone bricks
+        result: infested mossy stone bricks
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_cracked_stone_bricks"
+        input: cracked stone bricks
+        result: infested cracked stone bricks
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_chiseled_stone_bricks"
+        input: chiseled stone bricks
+        result: infested chiseled stone bricks
+        group: "haunting"
+        cooktime: 10 seconds
+    register campfire recipe:
+        id: "turtle:haunt_deepslate"
+        input: deepslate
+        result: infested deepslate
+        group: "haunting"
+        cooktime: 10 seconds


### PR DESCRIPTION
- Haunting campfire recipes that only work on soul campfires. Hauntable items will get stuck forever if placed onto a normal campfire
- Update Skript to 2.11.2
- Fix advancement tab backgrounds for 1.21.5
- Add portal radio cake
- Don't send magnifying glass info if there is no info