### PR TITLE
Misc improvements + bug fixes

### DIFF
--- a/datapacks/TurtleRealm/data/minecraft/loot_table/entities/ravager.json
+++ b/datapacks/TurtleRealm/data/minecraft/loot_table/entities/ravager.json
@@ -15,8 +15,21 @@
             },
             {
               "function": "minecraft:set_count",
-              "count": 1,
-              "add": false
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 1,
+                "max": 2
+              }
+            },
+            {
+              "function": "minecraft:enchanted_count_increase",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 0,
+                "max": 1
+              },
+              "limit": 3,
+              "enchantment": "minecraft:looting"
             }
           ]
         }

--- a/scripts/_utils/game/name.sk
+++ b/scripts/_utils/game/name.sk
@@ -14,21 +14,42 @@ expression:
         set string tag "minecraft:rarity" of nbt of raw expr-1 to change value
 
 # Effective name
-# Get the effective name of an item
-# Will return a translate component if no custom name
+# Get the effective name of an item or entity
+# Result may contain translate components
 expression:
     patterns:
         [the] (effective|real) [item] name of %item%
         %item%'s (effective|real) [item] name
     get:
-        if expr-1 is air:
-            return {_}
-        if name of expr-1 is set:
-            return (name of expr-1) + "§r"
-        else if component item name of expr-1 isn't "":
-            return component item name of expr-1 + "§r"
+        set {_item} to expr-1
+        if {_item} is air:
+            return translate component from (translation key of {_item})
+        if name of {_item} is set:
+            return (name of {_item}) + "§r"
+        else if (component item name of {_item}) isn't "":
+            return (component item name of {_item}) + "§r"
         else:
-            return translate component from (translation key of expr-1)
+            return translate component from (translation key of {_item})
+expression:
+    patterns:
+        [the] (effective|real) [entity] name of %entity%
+        %entity%'s (effective|real) [entity] name
+    get:
+        set {_e} to expr-1
+        set {_real_name} to (translate component from (translation key of {_e}))
+        set {_custom_name} to (custom name of {_e})
+        set {_variant} to (try {_e}.getVariant()) ? (try {_e}.getCatType()) ? (try {_e}.getColor()) ? (try {_e}.getCombinedGene()) ? ((translate component from (villager profession of {_e}).translationKey()) if (villager profession of {_e} isn't (no profession)) else "Unemployed")
+        if {_variant} is set:
+            if (try {_variant}.getKey()) is set:
+                set {_variant} to {_variant}.getKey().getKey()
+            set {_variant} to (strict proper case str({_variant}))
+            set {_mob_name} to merge components "%{_variant}% ", {_real_name}
+        else:
+            set {_mob_name} to {_real_name}
+        if {_custom_name} is set:
+            return "%{_custom_name}% (%{_mob_name}%)"
+        else:
+            return "%{_mob_name}%"
 
 # Item chat component
 # Mimics how minecraft displays items in chat

--- a/scripts/chat/commands/lookat.sk
+++ b/scripts/chat/commands/lookat.sk
@@ -4,3 +4,4 @@ brig command /turtle:lookat <blockpos>:
         {enabledFeatures::commands} is true
         set {_eyeHeight} to (y-coord of player's eye location) - (y-coord of player's location)
         make player look at ({_blockpos} ~ vector(0.5,0.5-{_eyeHeight},0.5))
+        play sound "minecraft:block.note_block.hat" in player category with volume 0.5 and pitch 1.5 at player to player

--- a/scripts/customItems.sk
+++ b/scripts/customItems.sk
@@ -147,8 +147,6 @@ expression:
         if (int tag "minecraft:damage" of (nbt of {_item})) is 0:
             (int tag "minecraft:damage" of (vanilla nbt of {_rawitem})) isn't set
             delete (int tag "minecraft:damage" of (nbt of {_item}))
-        if (nbt of {_item}) is (nbt of {_rawitem}):
-            return {_item}
         set {_newitem} to (item amount of {_item}) of (type of {_rawitem})
         add nbt of {_item} to nbt of {_newitem}
         add nbt of {_rawitem} to nbt of {_newitem}

--- a/scripts/entities/villager.sk
+++ b/scripts/entities/villager.sk
@@ -22,6 +22,7 @@ on entity start pathfinding:
     set {_workstation} to event-entity's work station
     {_workstation} is set
     if any:
+        {_workstation} is air
         world of event-entity isn't world of {_workstation}
         distance between event-entity and {_workstation} > 256
     then:
@@ -52,7 +53,7 @@ on right click on villager:
             cancel event
             event-entity.resetOffers()
             play sound "entity.villager.trade" in neutral category from event-entity
-            play sound "block.enchantment_table.use" with volume 0.2 and pitch 2
+            play sound "block.enchantment_table.use" with volume 0.5 and pitch 2
             make 15 of enchant at (event-entity's head)
             make player swing their hand
             player's gamemode isn't creative

--- a/scripts/items/custom/chorium_case.sk
+++ b/scripts/items/custom/chorium_case.sk
@@ -55,6 +55,7 @@ on custom item interact with "turtle:chorium_case_filled":
     set {_startLoc} to (player's location)
     relative tp player to {_hit}
     set fall distance of player to 0
+    set {-playerdata::%player%::canCloudJump} to true
     set (boolean tag "ignore_fall_damage_from_current_explosion" of (full nbt of player)) to false
     set {_v} to normalized (vector from {_startLoc} to {_hit})
     set {_amount} to ceil(distance between {_startLoc} and {_hit})

--- a/scripts/items/custom/magnifying_glass.sk
+++ b/scripts/items/custom/magnifying_glass.sk
@@ -32,24 +32,12 @@ on right click:
     set {_b} to (clicked block)
     if {_e} is set:
         # name
-        set {_real_name} to (translate component from (translation key of {_e}))
-        set {_custom_name} to (custom name of {_e})
-        set {_variant} to (try {_e}.getVariant()) ? (try {_e}.getCatType()) ? (try {_e}.getColor()) ? (try {_e}.getCombinedGene()) ? ((translate component from (villager profession of {_e}).translationKey()) if (villager profession of {_e} isn't (no profession)) else "Unemployed")
-        if {_variant} is set:
-            if (try {_variant}.getKey()) is set:
-                set {_variant} to {_variant}.getKey().getKey()
-            set {_variant} to (strict proper case str({_variant}))
-            set {_mob_name} to merge components "%{_variant}% ", {_real_name}
-        else:
-            set {_mob_name} to {_real_name}
-        if {_custom_name} is set:
-            add "§7🔎 §f%{_custom_name}% (%{_mob_name}%)" to {_info::*}
-        else:
-            add "§7🔎 §f%{_mob_name}%" to {_info::*}
+        set {_name} to (effective entity name of {_e})
+        add "§7🔎 §f%{_name}%" to {_info::*}
         # health
         if {_e} is a living entity:
-            set {_health} to ({_e}.getHealth())
-            set {_max_health} to ({_e}.getMaxHealth())
+            set {_health} to round({_e}.getHealth())
+            set {_max_health} to round({_e}.getMaxHealth())
             add "   §c❤ §7%{_health}%/%{_max_health}%" to {_info::*}
         # owner
         if owner of {_e} is set:

--- a/scripts/items/custom/mob_bundle.sk
+++ b/scripts/items/custom/mob_bundle.sk
@@ -44,6 +44,7 @@ on player interact on entity:
     wait 2 ticks
     (item id of (player's tool)) is "turtle:mob_bundle"
     set {_fill} to (((spawn item of event-entity) ? barrier) with nbt from "{components:{max_stack_size:1,custom_data:{from_mob_bundle:1b}}}")
+    set (name of {_fill}) to "§r%effective entity name of event-entity%"
     set {_nbt} to nbt of event-entity
     set compound tag "entityData" of custom nbt of {_fill} to {_nbt}
     set string tag "entityType" of custom nbt of {_fill} to str(event-entity.getType().getKey())
@@ -65,7 +66,7 @@ on player interact on entity:
     then:
         grantAdvancement("turtle:adventure/kidnapping", player)
     if event-equipmentslot is off hand slot:
-        set player's offhand tool to (player's tool)
+        set player's offhand tool to (player's offhand tool)
     else:
         set player's tool to (player's tool)
 

--- a/scripts/server.sk
+++ b/scripts/server.sk
@@ -3,7 +3,7 @@ options:
     resourcePackUrl: "https://chicknturtle.ninja/downloads/§aTurtleRealmSMP.zip"
     resourcePackHash: "c1a8db0152b23a64a4e38abda847aa958a84eb66"
     resourcePackPrompt: "§bRequired to see custom item textures and other important things"
-    resourcePackDeclineMsg: "§cYou have declined the server resource pack. You can fix this by changing the setting on your server list."
+    resourcePackDeclineMsg: "§cYou have declined the server resource pack."
 
 # gamerules
 on load:
@@ -15,10 +15,7 @@ on load:
 # send resource pack
 on join:
     sendResourcePack(player)
-    player.getResourcePackStatus() is decline
-    send {@resourcePackDeclineMsg} to player
-
-    unlock recipes all recipes for player
+    unlock recipes (all recipes) for player
 
 import:
     java.util.UUID


### PR DESCRIPTION
- Teleporting with chorium case now refreshes your cloud jump
- Villagers forget distant removed workstations faster
- Ravagers now drop 1-2 hide or up to 3 with looting
- Mob bundle spawn egg item now displays the mob's name and type
- Rename item-name util to name and add effective name for entities
- /lookat now plays a small sound
- Magnifying glass health display is now rounded
- Fix duping of mob bundles
- Fix custom items not being updated when nbt but not base item matches
- Fix resource pack decline msg sending twice (also fixes recipes not being unlocked)