### PR TITLE
NBS Upgrades + more

### DIFF
--- a/config.sk
+++ b/config.sk
@@ -405,7 +405,7 @@ databases:
 		
 		# ==== Settings that should not be changed ====
 		
-version: 2.12.0-pre2
+version: 2.12.0
 # DO NOT CHANGE THIS VALUE MANUALLY!
 # This saves for which version of Skript this configuration was written for.
 # If it does not match the version of the .jar file then the config will be updated automatically.

--- a/scripts/_utils/game/name.sk
+++ b/scripts/_utils/game/name.sk
@@ -26,7 +26,7 @@ expression:
             return translate component from (translation key of {_item})
         if name of {_item} is set:
             return (name of {_item}) + "§r"
-        else if (component item name of {_item}) isn't "":
+        else if (try {_item}.getItemMeta().hasItemName()):
             return (component item name of {_item}) + "§r"
         else:
             return translate component from (translation key of {_item})
@@ -60,7 +60,7 @@ expression:
     get:
         set {_col} to rarity color of expr-1
         set {_name} to (effective item name of expr-1)
-        set {_c} to text component from "[%{_name}%]"
+        set {_c} to (merge components (text component from "["), {_name}, (text component from "]"))
         set color format of {_c} to {_col}
         set hover event of {_c} to hover event showing expr-1
         return {_c}

--- a/scripts/_utils/utils/async.sk
+++ b/scripts/_utils/utils/async.sk
@@ -1,0 +1,6 @@
+
+import:
+    java.lang.Thread as javaThread
+
+function threadSleep(ms:integer):
+    javaThread.sleep({_ms})

--- a/scripts/_utils/utils/debug.sk
+++ b/scripts/_utils/utils/debug.sk
@@ -3,23 +3,8 @@
 # Makes a small particle and sound at a location.
 effect:
     patterns:
-        [make|play] [a] (debug|pop|debug pop) [effect] [at] %location%
+        [make|play] [a] (debug|pop|debug pop) [effect] [at] %locations%
     trigger:
-        make 1 of flame at expr-1 with extra 0
-        play sound "minecraft:block.note_block.xylophone" at expr-1
-
-function broadcast(val:object, name:string={_}):
-    if {_name} is set:
-        broadcast "%{_name}%: %{_val}%"
-    else:
-        broadcast "%{_val}%"
-
-function broadcasts(val:objects, name:string={_}):
-    set {_val} to "%{_val::*}%"
-    if {_name} is set:
-        broadcast "%{_name}%: %{_val}%"
-    else:
-        broadcast "%{_val}%"
-
-function actionbar(val:object):
-    send actionbar "%{_val}%" to (all players where [input is op])
+        loop exprs-1:
+            make 1 of flame at loop-value with extra 0
+            play sound "minecraft:block.note_block.xylophone" at loop-value

--- a/scripts/_utils/utils/info.sk
+++ b/scripts/_utils/utils/info.sk
@@ -14,7 +14,7 @@ local function playerInfo(p:player) :: string:
         add "§8%uuid of {_p}%" to {_lines::*}
     return (join {_lines::*} with "§r%nl%")
 
-function playerComponent(p:offline player) :: object:
+function playerComponent(p:player) :: object:
     set {_c} to text component from ({_p}'s display name)
     set hover event of {_c} to (hover event showing (playerInfo({_p})))
     set click event of {_c} to (click event to suggest command "/msg %{_p}%")

--- a/scripts/chat/advancements.sk
+++ b/scripts/chat/advancements.sk
@@ -42,7 +42,7 @@ on advancement done:
     else:
         set {_c::3} to (text component from " §7(%{_completed}%/%{_total}%)")
     set (hover event of {_c::2}) to (hover event showing "%{_c}%%{_title}%%nl%%{_desc}%")
-    broadcast component (merge components {_c::*})
+    send component (merge components {_c::*}) to (all players and console)
 
     discordSend(":trophy: %player% has completed **[%{_title}%]** *(%{_completed}%/%{_total}%)*")
 

--- a/scripts/chat/chat.sk
+++ b/scripts/chat/chat.sk
@@ -19,7 +19,7 @@ on join:
     set {_c::2} to playerComponent(player)
     set {_c::3} to " joined the game"
     clear join message
-    broadcast components (merge components {_c::*})
+    send components (merge components {_c::*}) to (all players and console)
     discordSend("**+** %player%")
 
 on leave:
@@ -28,7 +28,7 @@ on leave:
     set {_c::2} to playerComponent(player)
     set {_c::3} to " left the game"
     clear leave message
-    broadcast components (merge components {_c::*})
+    send components (merge components {_c::*}) to (all players and console)
     discordSend("**-** %player%")
 
 on death of player:

--- a/scripts/discord/chatlink.sk
+++ b/scripts/discord/chatlink.sk
@@ -37,8 +37,8 @@ on message received:
     {enabledFeatures::discordlink} is true
     event-user isn't a discord bot
     discord id of event-channel is {-env::discordLinkChannel}
-    set {_c::1} to text component from "%effective name of event-member%:"
-    set {_c::2} to text component from " &f%event-message%"
-    set color format of {_c::1} to rgb(88, 101, 242)
-    set hover event of {_c::1} to hover event showing "§f%event-user%%nl%§7@%discord name of event-user%"
-    broadcast component (merge components {_c::*})
+    set {_c::1} to (text component from "%effective name of event-member%:")
+    set (color format of {_c::1}) to (rgb(88, 101, 242))
+    set (hover event of {_c::1}) to (hover event showing "§f%event-user%%nl%§7@%discord name of event-user%")
+    set {_c::2} to " &f%event-message%"
+    send component (merge components {_c::*}) to (all players and console)

--- a/scripts/discord/commands.sk
+++ b/scripts/discord/commands.sk
@@ -24,19 +24,13 @@ slash command exec <string="command">:
         code: Command to execute
     trigger:
         # permission
-        set {_linked::*} to (indexes of {discordLinks::*} where [{discordLinks::%input%} is (discord id of event-user)])
-        set {_linked} to (first element of {_linked::*})
-        if any:
-            {_linked} isn't set
-            {-env::opPlayers::*} doesn't contain {_linked}
-        then:
-            reply with hidden "You don't have permission to do this."
-            exit trigger
-        else:
-            # execute
+        if {-env::discordExecIds::*} contains (discord id of event-user):
             set {_command} to argument "command" as string
             log info "Executing command from discord: §3%{_command}%"
             if parse effect {_command} = true:
                 reply with hidden ":white_check_mark: Successfully executed `%{_command}%`"
             else:
                 reply with hidden ":warning: Failed to execute `%{_command}%`"
+        else:
+            reply with hidden "You don't have permission to do this."
+            exit trigger

--- a/scripts/items/custom/custom_music_disc.sk
+++ b/scripts/items/custom/custom_music_disc.sk
@@ -13,17 +13,14 @@ when ready to load recipes:
             set ingredient of "g" to gold ingot
             set ingredient of "d" to diamond
 
-function updateCustomMusicDisc(disc:item) :: item:
-    set {_name} to name of {_disc}
-    set {_song} to getNbsSong({_name})
-    if any:
-        {_name} isn't set
-        {_song} isn't set
-    then:
+function updateCustomMusicDisc(disc:item, song:object={_}) :: item:
+    if {_song} isn't set:
         clear lore of {_disc}
         return {_disc}
+    if {_song}.title ? "" isn't "":
+        add "§7%{_song}.title%" to {_c::*}
     if {_song}.author ? "" isn't "":
-        add "§7%{_song}.author%" to {_c::*}
+        add "§7by %{_song}.author%" to {_c::*}
     if {_song}.originalAuthor ? "" isn't "":
         add "§7Originally by %{_song}.originalAuthor%" to {_c::*}
     set {_c::*} to {_c::*} ? "§7No song info"
@@ -32,7 +29,12 @@ function updateCustomMusicDisc(disc:item) :: item:
 
 on anvil prepare:
     item id of event-slot is "turtle:custom_music_disc"
-    set event-slot to updateCustomMusicDisc(event-slot)
-    name of event-slot is set
-    lore of event-slot isn't set
+    if (name of event-slot) isn't set:
+        set event-slot to updateCustomMusicDisc(event-slot)
+        exit
+    set {_disc} to (item in event-slot)
     set event-slot to air
+    run section {-sections::getNbsSong} async with (name of {_disc}) and store result in {_song} and wait
+    item id of (slot 0 of event-inventory) is "turtle:custom_music_disc"
+    {_song} is set
+    set (slot 2 of event-inventory) to updateCustomMusicDisc({_disc}, {_song})

--- a/scripts/items/custom/tree_bark.sk
+++ b/scripts/items/custom/tree_bark.sk
@@ -2,8 +2,19 @@
 when ready to register custom items:
     set (custom item "turtle:tree_bark") to (stick with nbt from "{""minecraft:item_model"":""turtle:tree_bark"",""minecraft:item_name"":""Tree Bark""}")
 
+when ready to load recipes:
+    register shaped recipe:
+        id: "turtle:paper_from_bark"
+        category: "misc"
+        shape: "###"
+        result: paper
+        ingredients:
+            set ingredient of "#" to (custom item "turtle:tree_bark")
+
 on player interact:
     event-blockaction is right_click_block
     event-block is tagged with block tag "turtle:strippable_logs"
     event-item is tagged with item tag "minecraft:axes"
+    wait 1 tick
+    event-block isn't tagged with block tag "turtle:strippable_logs"
     drop 1 of (custom item "turtle:tree_bark") at ((exact location of event-block) ~ event-vector) without velocity

--- a/scripts/processing/pressing-recipes.sk
+++ b/scripts/processing/pressing-recipes.sk
@@ -1,5 +1,5 @@
 
-local function getSimpleResult(item:item,amount:integer=1,chance:number=1) :: objects:
+local function getSimpleResult(item:itemtype,amount:integer=1,chance:number=1) :: objects:
     return {_item}, {_amount}, {_chance}
 
 function addPressingRecipe(input:string, results:objects):
@@ -58,16 +58,17 @@ when ready to load recipes:
     addPressingRecipe("minecraft:clay", (getSimpleResult(clay_ball, 3), getSimpleResult(clay_ball, 1, 0.5)))
     addPressingRecipe("minecraft:dripstone_block", getSimpleResult(clay_ball))
     addPressingRecipe("minecraft:glowstone", (getSimpleResult(glowstone_dust, 3), getSimpleResult(glowstone_dust, 1, 0.5)))
-    addPressingRecipe("minecraft:white_wool", getSimpleResult(string))
+    loop "white", "light_gray", "gray", "black", "brown", "red", "orange", "yellow", "lime", "green", "cyan", "light_blue", "blue", "purple", "magenta", "pink":
+        addPressingRecipe("minecraft:%loop-value%_wool", (getSimpleResult(string item,2),getSimpleResult(string item,1,0.5)))
     addPressingRecipe("minecraft:blaze_rod", (getSimpleResult(blaze_powder, 3), getSimpleResult(blaze_powder, 3, 0.25)))
     addPressingRecipe("minecraft:amethyst_cluster", (getSimpleResult(amethyst_shard, 7), getSimpleResult(amethyst_shard, 1, 0.5)))
     addPressingRecipe("minecraft:block_of_amethyst", (getSimpleResult(amethyst_shard, 3), getSimpleResult(amethyst_shard, 1, 0.5)))
     addPressingRecipe("minecraft:prismarine_crystals", (getSimpleResult(quartz, 1), getSimpleResult(quartz, 2, 0.5), getSimpleResult(glowstone_dust, 2, 0.1)))
     addPressingRecipe("minecraft:nether_wart_block", getSimpleResult(nether_wart, 1, 0.25))
-    addPressingRecipe("minecraft:diamond_horse_armor", (getSimpleResult(diamond, 1), getSimpleResult(leather, 2, 0.5), getSimpleResult(diamond, 3, 0.1), getSimpleResult(string, 2, 0.25)))
-    addPressingRecipe("minecraft:golden_horse_armor", (getSimpleResult(gold_ingot, 2), getSimpleResult(leather, 2, 0.5), getSimpleResult(gold_ingot, 2, 0.5), getSimpleResult(string, 2, 0.25), getSimpleResult(gold_nugget, 8, 0.25)))
-    addPressingRecipe("minecraft:iron_horse_armor", (getSimpleResult(iron_ingot, 2), getSimpleResult(leather, 2, 0.5), getSimpleResult(iron_ingot, 2, 0.5), getSimpleResult(string, 2, 0.25), getSimpleResult(iron_nugget, 8, 0.25)))
-    addPressingRecipe("minecraft:leather_horse_armor", (getSimpleResult(leather, 4), getSimpleResult(leather, 2, 0.5), getSimpleResult(string, 2, 0.25)))
+    addPressingRecipe("minecraft:diamond_horse_armor", (getSimpleResult(diamond, 1), getSimpleResult(leather, 2, 0.5), getSimpleResult(diamond, 3, 0.1), getSimpleResult(string item, 2, 0.25)))
+    addPressingRecipe("minecraft:golden_horse_armor", (getSimpleResult(gold_ingot, 2), getSimpleResult(leather, 2, 0.5), getSimpleResult(gold_ingot, 2, 0.5), getSimpleResult(string item, 2, 0.25), getSimpleResult(gold_nugget, 8, 0.25)))
+    addPressingRecipe("minecraft:iron_horse_armor", (getSimpleResult(iron_ingot, 2), getSimpleResult(leather, 2, 0.5), getSimpleResult(iron_ingot, 2, 0.5), getSimpleResult(string item, 2, 0.25), getSimpleResult(iron_nugget, 8, 0.25)))
+    addPressingRecipe("minecraft:leather_horse_armor", (getSimpleResult(leather, 4), getSimpleResult(leather, 2, 0.5), getSimpleResult(string item, 2, 0.25)))
     addPressingRecipe("minecraft:saddle", (getSimpleResult(leather, 2), getSimpleResult(leather, 2, 0.5)))
     addPressingRecipe("minecraft:raw_copper_block", (getSimpleResult(custom item "turtle:crushed_raw_copper", 9), getSimpleResult(custom item "turtle:experience_nugget", 9, 0.75)))
     addPressingRecipe("minecraft:raw_gold_block", (getSimpleResult(custom item "turtle:crushed_raw_gold", 9), getSimpleResult(custom item "turtle:experience_nugget", 9, 0.75)))

--- a/scripts/stuff/inv-sorting.sk
+++ b/scripts/stuff/inv-sorting.sk
@@ -1,11 +1,9 @@
 
 on inventory click:
     (event-item ? air) is air
-    if all:
-        event-clicktype isn't middle mouse button
-        event-clicktype isn't double click using mouse
-    then:
-        exit
+    set {_cursor} to (player's cursor slot)
+    ({_cursor} ? air) is air
+    event-clicktype is (middle mouse button) or (double click using mouse)
     if all:
         (player inventory, chest, trapped chest, barrel, (tag contents of block tag "shulker_boxes"), minecart with chest, chest boat) doesn't contain (holder of event-inventory)
         event-inventory isn't (ender chest of player)
@@ -39,4 +37,4 @@ on inventory click:
     else:
         clear event-inventory
         add {_finalStacks::*} to event-inventory
-    play sound "minecraft:ui.button.click" in ui with volume 0.5 with pitch 2 for player
+    play sound "minecraft:ui.button.click" in ui with volume 0.5 with pitch 2 for (viewers of event-inventory)

--- a/scripts/stuff/nbs.sk
+++ b/scripts/stuff/nbs.sk
@@ -1,6 +1,7 @@
 
 import:
     java.io.File
+    java.lang.System
     com.xxmicloxx.NoteBlockAPI.NoteBlockAPI
     com.xxmicloxx.NoteBlockAPI.utils.NBSDecoder
     com.xxmicloxx.NoteBlockAPI.songplayer.PositionSongPlayer
@@ -13,52 +14,96 @@ function getBlockKey(block:block) :: string:
 function getAllNbsFiles() :: objects:
     set {_file} to new File("nbsSongs")
     {_file}.exists() is true
-    loop ...{_file}.listFiles() where [input.getName() ends with ".nbs"]:
+    set {_files::*} to (...{_file}.listFiles() where [input.getName() ends with ".nbs"])
+    sort {_files::*} by input.lastModified()
+    loop {_files::*}:
         add getFileName(loop-value.getName()) to {_names::*}
     return {_names::*}
 
-function getNbsSong(songName:string) :: object:
-    if {_songName} isn't set:
-        return {_}
-    set {_file} to new File("nbsSongs/%{_songName}%.nbs")
-    if {_file}.exists() is true:
-        return NBSDecoder.parse({_file})
+on load:
+    create new section with {_songName} stored in {-sections::getNbsSong}:
+        # return from cache
+        if {-nbsSongCache::%{_songName}%} is set:
+            return {-nbsSongCache::%{_songName}%}
+        # wait until song is loaded, give up after 10s
+        else if {-loadingNbsSongs::%{_songName}%} is set:
+            while {-loadingNbsSongs::%{_songName}%} is set:
+                threadSleep(100)
+                loop-iteration > 100
+                exit loop
+        # load song from file
+        else:
+            set {-loadingNbsSongs::%{_songName}%} to true
+            set {_file} to new File("nbsSongs/%{_songName}%.nbs")
+            {_file}.exists() is true
+            log debug "Loading and caching song '%{_songName}%'"
+            {_file}.setLastModified(System.currentTimeMillis())
+            set {-nbsSongCache::%{_songName}%} to NBSDecoder.parse({_file})
+        delete {-loadingNbsSongs::%{_songName}%}
+        return {-nbsSongCache::%{_songName}%}
+    create new section stored in {-sections::clearOldNbsFiles}:
+        set {_dir} to new File("nbsSongs")
+        # 30 days ago
+        set {_cutoff} to System.currentTimeMillis() - 30*24*60*60*1000
+        loop ...{_dir}.listFiles():
+            getFileExt(loop-value.getName()) is "nbs"
+            loop-value.lastModified() < {_cutoff}
+            log debug "Deleting file: %loop-value.getName()%"
+            loop-value.delete()
+            add 1 to {_deleted}
+        if {_deleted} is set:
+            log info "Cleared %{_deleted}% old nbs file(s)"
+        return {_deleted} ? 0
+    
+    run section {-sections::clearOldNbsFiles} async
 
-function playNbsSongAtBlock(songName:string, block:block) :: boolean:
-    set {_song} to getNbsSong({_songName})
-    if {_song} is set:
-        set {_songPlayer} to new PositionSongPlayer({_song}, SoundCategory.RECORDS)
-        {_songPlayer}.setTargetLocation(location of {_block})
-        {_songPlayer}.setDistance(64)
-        loop all players in world of {_block}:
-            {_songPlayer}.addPlayer(loop-player)
-        {_songPlayer}.setPlaying(true)
-        stopNbsSongOfBlock({_block})
-        set {-playingNbsSongs::%getBlockKey({_block})%} to {_songPlayer}
-        return true
-    return false
+every 5 minutes:
+    size of {-nbsSongCache::*} > 0
+    log debug "Automatically clearing %size of {-nbsSongCache::*}% song(s) from cache"
+    clear {-nbsSongCache::*}
+
+function playNbsSongAtBlock(song:object, block:block) :: boolean:
+    set {_songPlayer} to new PositionSongPlayer({_song}, SoundCategory.RECORDS)
+    {_songPlayer}.setTargetLocation(location of {_block})
+    {_songPlayer}.setDistance(64)
+    loop all players in world of {_block}:
+        {_songPlayer}.addPlayer(loop-player)
+    {_songPlayer}.setPlaying(true)
+    stopNbsSongOfBlock({_block})
+    set {-playingNbsSongs::%getBlockKey({_block})%} to {_songPlayer}
+
+# Temporary fix until .destroy() is fixed to remove from playingSongs map
+function destroySongPlayer(songPlayer:object):
+    loop ...NoteBlockAPI.getAPI().playingSongs.keySet():
+        {_songPlayer}.removePlayer(loop-value)
+    {_songPlayer}.destroy()
 
 function stopNbsSongOfBlock(block:block):
     set {_songPlayer} to {-playingNbsSongs::%getBlockKey({_block})%}
     {_songPlayer} is set
-    {_songPlayer}.destroy()
+    destroySongPlayer({_songPlayer})
     delete {-playingNbsSongs::%getBlockKey({_block})%}
 
 function stopAllNbsSongs():
     loop {-playingNbsSongs::*}:
-        loop-value.destroy()
+        destroySongPlayer(loop-value)
     clear {-playingNbsSongs::*}
 
 on game event jukebox_play:
     set {_block} to (block at event-location)
-    long tag "ticks_since_song_started" of nbt of {_block} is 0
+    long tag "ticks_since_song_started" of (nbt of {_block}) is 0
     set {_disc} to (blockstate of {_block}).getRecord()
     (item id of {_disc}) is "turtle:custom_music_disc"
     set {_songName} to (name of {_disc})
-    if {_songName} is set:
-        playNbsSongAtBlock({_songName}, {_block}) is true
-        exit trigger
-    (blockstate of {_block}).stopPlaying()
+    {_songName} is set
+    run section {-sections::getNbsSong} async with {_songName} and store result in {_song} and wait
+    {_song} is set
+    {_block} is a jukebox
+    (blockstate of {_block}).isPlaying() is true
+    set {_updated} to updateCustomMusicDisc((slot 0 of inventory of {_block}), {_song})
+    if (slot 0 of inventory of {_block}) isn't {_updated}:
+        set (slot 0 of inventory of {_block}) to {_updated}
+    playNbsSongAtBlock({_song}, {_block})
 
 on game event jukebox_stop_play:
     set {_block} to (block at event-location)
@@ -84,30 +129,75 @@ brig command tree /turtle:nbs:
     literal arg "list":
         optional int arg "page":
             trigger:
-                set {_songs::*} to sorted getAllNbsFiles()
+                set {_songs::*} to reversed getAllNbsFiles()
                 if size of {_songs::*} is 0:
-                    send "§cNo songs are available."
+                    send "§6No songs are available. Try uploading one on discord with §e/uploadnbs <file>§6."
                 else:
-                    set {_pageAmount} to 8
-                    set {_maxPages} to ceil(size of {_songs::*} / {_pageAmount})
+                    set {_perPage} to 16
+                    set {_maxPages} to ceil(size of {_songs::*} / {_perPage})
                     set {_page} to clamp({_page} ? 1, 1, {_maxPages})
-                    set {_start} to {_pageAmount}*{_page}-{_pageAmount}+1
-                    set {_end} to min(size of {_songs::*}, {_pageAmount}*{_page})
-                    send "§6Page §e%{_page}%/%{_maxPages}% §7(showing §3#%{_start}%-%{_end}%§7 out of %size of {_songs::*}%)"
+                    set {_start} to {_perPage}*{_page}-{_perPage}+1
+                    set {_end} to min((size of {_songs::*}), {_perPage}*{_page})
+                    send "§6Listing songs §e#%{_start}%-%{_end}%§6 out of %size of {_songs::*}%:"
                     set {_shown::*} to (elements from {_start} to {_end} of {_songs::*})
                     loop {_shown::*}:
-                        set {_c} to (text component from " §b%loop-value%")
-                        set (hover event of {_c}) to (hover event showing "§bClick to copy to clipboard")
-                        set (click event of {_c}) to (click event to copy loop-value to clipboard)
-                        add {_c} to {_shownC::*}
+                        set {_c} to (text component from " §3%{_start}-1+loop-iteration%. §b%loop-value%")
+                        set (hover event of {_c}) to (hover event showing "§b%loop-value%%nl%§3Click to apply to held disc")
+                        set (click event of {_c}) to (click event to run command "/nbs apply %loop-value%")
+                        add {_c} to {_c::*}
                         loop-iteration isn't (size of {_shown::*})
-                        add nl to {_shownC::*}
-                    send components (merge components {_shownC::*})
+                        add nl to {_c::*}
+                    add nl to {_c::*}
+                    set {_c} to "§8⏪⏪⏪⏪⏪"
+                    if {_page} > 1:
+                        set {_c} to text component from "§2⏪⏪⏪⏪⏪"
+                        set (click event of {_c}) to (click event to run command "/nbs list %{_page}-1%")
+                    add {_c} to {_c::*}
+                    add " §a%{_page}%/%{_maxPages}% " to {_c::*}
+                    set {_c} to "§8⏩⏩⏩⏩⏩"
+                    if {_page} < {_maxPages}:
+                        set {_c} to text component from "§2⏩⏩⏩⏩⏩"
+                        set (click event of {_c}) to (click event to run command "/nbs list %{_page}+1%")
+                    add {_c} to {_c::*}
+                    send components (merge components {_c::*})
+    literal arg "apply":
+        greedy string arg "name":
+            suggestions:
+                apply suggestion getAllNbsFiles()
+            trigger:
+                if (item id of player's tool) isn't "turtle:custom_music_disc":
+                    send "§6Hold a Custom Music Disc to apply a song."
+                else:
+                    if getAllNbsFiles() contains {_name}:
+                        run section {-sections::getNbsSong} async with {_name} and store result in {_song} and wait
+                        if (item id of player's tool) is "turtle:custom_music_disc":
+                            set (name of player's tool) to {_name}
+                            set (player's tool) to updateCustomMusicDisc(player's tool, {_song})
+                            play sound "minecraft:ui.cartography_table.take_result" in ui to player
+                        else:
+                            set {_c} to (text component from "§bTry again?")
+                            set (hover event of {_c}) to (hover event showing "§b%{_name}%%nl%§3Click to apply to held disc")
+                            set (click event of {_c}) to (click event to run command "/nbs apply %{_name}%")
+                            send component (merge components "§cYou switched off the disc too fast. ", {_c})
+                    else:
+                        send "§cThe song '%{_name}%§r§c' doesn't exist. §6Use /nbs list to list all songs."
     literal arg "stopall":
         permission: op
         trigger:
             send "Stopped %size of {-playingNbsSongs::*}% song player(s)"
             stopAllNbsSongs()
+    literal arg "clearcache":
+        permission: op
+        trigger:
+            send "Cleared %size of {-nbsSongCache::*}% song(s) from cache"
+            size of {-nbsSongCache::*} > 0
+            log info "Cleared %size of {-nbsSongCache::*}% song(s) from cache"
+            clear {-nbsSongCache::*}
+    literal arg "deleteoldsongs":
+        permission: op
+        trigger:
+            run section {-sections::clearOldNbsFiles} async and store result in {_cleared} and wait
+            send "Cleared %{_cleared}% old nbs file(s)"
 
 slash command uploadnbs <attachment="file">:
     description: Upload a song file to use with a Custom Music Disc
@@ -115,30 +205,47 @@ slash command uploadnbs <attachment="file">:
     arguments:
         file: File to upload, must be a .nbs file
     trigger:
-        # linked user
-        loop indexes of {discordLinks::*}:
-            {discordLinks::%loop-value%} is (discord id of event-user)
-            set {_linkeduuid} to loop-value
-            exit loop
-        if {_linkeduuid} isn't set:
-            reply with hidden "You must have your account linked to upload a song!"
-            exit trigger
-        # check .nbs file
-        set {_file} to argument "file" as attachment
-        if file extension of {_file} isn't "nbs":
-            reply with hidden "**Not a song file.** File must end with .nbs"
-            exit trigger
-        # download file
-        set {_filenameNoExt} to getFileName(file name of {_file})
-        set {_filename} to first 30 characters of {_filenameNoExt}
-        replace "_" with " " in {_filename}
-        download {_file} to path "nbsSongs/%{_filename}%.nbs"
-        log info "%event-user% uploaded '%{_filename}%.nbs'"
-        # check if corrupted
-        wait 1 second
-        if getNbsSong({_filename}) is set:
-            reply with hidden "Successfully uploaded `%{_filename}%.nbs`%nl%Rename a Custom Music Disc to ""%{_filename}%"" to hear your song.%nl%Your file could be deleted or overwritten by another user, so don't lose your original file!"
-            discordSend(":cd: <@%discord id of event-user%> uploaded `%{_filename}%`")
-        else:
-            reply with hidden "Your file `%file name of {_file}%` isn't a valid song file! Try again with a valid file."
-            new File("nbsSongs/%{_filename}%.nbs").delete()
+        async run 0 ticks later:
+            # linked user
+            loop indexes of {discordLinks::*}:
+                {discordLinks::%loop-value%} is (discord id of event-user)
+                set {_linkeduuid} to loop-value
+                exit loop
+            if {_linkeduuid} isn't set:
+                reply with hidden "You must have your account linked to upload a song!"
+                exit trigger
+            # check .nbs file
+            set {_fileAttachment} to argument "file" as attachment
+            if file extension of {_fileAttachment} isn't "nbs":
+                reply with hidden "The file you tried to upload isn't a song file. Valid song files end with .nbs%nl%You can find valid song files on [Note Block World](<https://noteblock.world/>)."
+                exit trigger
+            # get filename
+            set {_filenameNoExt} to getFileName(file name of {_fileAttachment})
+            set {_filename} to (first 30 characters of {_filenameNoExt})
+            replace "_" with " " in {_filename}
+            set {_filename} to (try {_filename}.trim()) ? {_filename}
+            # msgs
+            log info "%event-user% is uploading '%{_filename}%.nbs'"
+            reply with hidden "Uploading `%{_filename}%.nbs`%nl%Your file could be deleted or overwritten by another user, so don't lose your original file!%nl%See [Custom Music Disc](<https://github.com/ChicknTurtle/TurtleRealmSMP-scripts/wiki/Custom-Music-Disc>) to learn how to listen to your song in-game."
+            # check if song file is valid
+            set {_inputStream} to {_fileAttachment}.getProxy().download().get()
+            set {_song} to try NBSDecoder.parse({_inputStream})
+            {_inputStream}.close()
+            if {_song} is set:
+                download {_fileAttachment} to path "nbsSongs/%{_filename}%.nbs"
+                log debug "Caching uploaded song '%{_filename}%'"
+                set {-nbsSongCache::%{_filename}%} to {_song}
+                set {_c::1} to "§b◎ "
+                set {_c::2} to (text component from (effective name of event-member))
+                set (color format of {_c::2}) to rgb(88, 101, 242)
+                set (hover event of {_c::2}) to (hover event showing "§f%event-user%%nl%§7@%discord name of event-user%")
+                set {_c::3} to " uploaded "
+                set {_c::4} to (text component from "§b%{_filename}%")
+                set (hover event of {_c::4}) to (hover event showing "§b%{_filename}%%nl%§3Click to apply to held disc")
+                set (click event of {_c::4}) to (click event to run command "/nbs apply %{_filename}%")
+                send component (merge components {_c::*}) to (all players and console)
+                discordSend(":cd: <@%discord id of event-member%> uploaded `%{_filename}%`")
+            else:
+                open private channel of event-user and store it in {_channel}
+                {_channel} is set
+                post "Your file `%file name of {_fileAttachment}%` was not uploaded because it was found to be an invalid song file.%nl%You can find valid song files on [Note Block World](<https://noteblock.world/>)." to {_channel}


### PR DESCRIPTION
- Update Skript from 2.12.0-pre2 to 2.12.0
- Nbs songs have a cache with efficient async loading
- Changes to uploading nbs songs through discord
- Upgrade /nbs list
- Added to /nbs command: apply, clearcache, deleteoldsongs
- Fix memory leak caused by NBAPI
- Custom Music Discs are updated when placed into a jukebox, not just when named
- Song files that haven't been loaded in 30 days will be deleted
- Fix tree bark duplication when holding shield
- Fix /exec on discord
- Small upgrades to inventory sorting
- Fix pressing recipes for string, increase string amount from pressing wool
- Fix item names when displaying items with '[item]'
- Remove old debug functions