### PR TITLE
Fix /ping, dispenser bonemeal stems

### DIFF
--- a/scripts/blocks/dispenser.sk
+++ b/scripts/blocks/dispenser.sk
@@ -32,7 +32,7 @@ on BlockPreDispenseEvent:
             dispenserBonemeal(event)
         # stem block
         else if (pumpkin stem, melon stem) contains (type of {_front_block}):
-            bonemealStemBlock({_front_block}) is true
+            bonemealStemBlock({_front_block}, 5) is true
             dispenserBonemeal(event)
         # single tick block
         else if (chorus flower) contains (type of {_front_block}):

--- a/scripts/chat/commands/heal.sk
+++ b/scripts/chat/commands/heal.sk
@@ -4,7 +4,6 @@ brig command /turtle:heal:
     arguments:
         register optional entities arg "entities"
     trigger:
-        {enabledFeatures::commands} is true
         set {_entities::*} to ({_entities::*} ? player)
         loop {_entities::*}:
             heal loop-value

--- a/scripts/chat/commands/lookat.sk
+++ b/scripts/chat/commands/lookat.sk
@@ -1,7 +1,6 @@
 
 brig command /turtle:lookat <blockpos>:
     trigger:
-        {enabledFeatures::commands} is true
         set {_eyeHeight} to (y-coord of player's eye location) - (y-coord of player's location)
         make player look at ({_blockpos} ~ vector(0.5,0.5-{_eyeHeight},0.5))
         play sound "minecraft:block.note_block.hat" in (player category) with volume 0.5 and pitch 1.5 at player to player

--- a/scripts/chat/commands/ping.sk
+++ b/scripts/chat/commands/ping.sk
@@ -1,15 +1,8 @@
 
-on load:
-    set {-features::commands::name} to "Commands"
-    set {-features::commands::desc} to "Simple but useful commands\nType '/turtle:' to show tab-completion for all commands"
-    set {-features::commands::warn} to "If disabled, commands will still be visible but not do anything"
-    set {-features::commands::icon} to command block
-
 brig command /turtle:ping:
     arguments:
-        register optional player arg "players"
+        register optional player arg "player"
     trigger:
-        {enabledFeatures::commands} is true
         set {_player} to ({_player} ? player)
         if {_player} isn't set:
             send "&cNo player was found"

--- a/scripts/chat/commands/repair.sk
+++ b/scripts/chat/commands/repair.sk
@@ -4,7 +4,6 @@ brig command /turtle:repair:
     arguments:
         register optional entities arg "entities"
     trigger:
-        {enabledFeatures::commands} is true
         set {_entities::*} to ({_entities::*} ? player)
         loop {_entities::*}:
             (max durability of (loop-value's tool)) isn't 0

--- a/scripts/stuff/bonemealing.sk
+++ b/scripts/stuff/bonemealing.sk
@@ -67,7 +67,7 @@ function bonemealFlowerBlock(block:block) :: boolean:
     return false
 
 # bonemeal via right-click
-# dispenser functionality in /tweaks/blocks/dispenser.sk
+# dispenser functionality in dispenser.sk
 
 on right click:
     {enabledFeatures::bonemealing} is true


### PR DESCRIPTION
- Fix getting ping of other players with /ping
- Remove 'commands' feature
- Make dispensers bonemeal pumpkins/melons blocks x5