### PR TITLE
More edible items, paxels mine hoeable blocks + more

### DIFF
--- a/datapacks/TurtleRealm/data/minecraft/loot_table/entities/warden.json
+++ b/datapacks/TurtleRealm/data/minecraft/loot_table/entities/warden.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:entity",
+  "pools": [
+    {
+      "bonus_rolls": 0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:sculk_catalyst"
+        }
+      ],
+      "rolls": 1
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:echo_shard",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1,
+              "conditions": []
+            },
+            {
+              "function": "minecraft:enchanted_count_increase",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 0,
+                "max": 1
+              },
+              "limit": 2,
+              "enchantment": "minecraft:looting"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "random_sequence": "minecraft:entities/warden"
+}

--- a/scripts/entities/shulker.sk
+++ b/scripts/entities/shulker.sk
@@ -45,11 +45,6 @@ on damage by shulker bullet:
         set damage to ((damage+3)*2.5)
 
 on death of shulker:
-    string tag "special" of custom nbt of victim is "vault_boss"
-    set {_amount} to (random integer from 1 to 2)
+    (string tag "special" of (custom nbt of victim)) is "vault_boss"
     set {_tool} to ((direct entity of damage source)'s tool)
-    if {_tool} is enchanted with looting:
-        loop (level of looting of {_tool}) times:
-            chance of 0.33
-            add 1 to {_amount}
-    drop {_amount} of (custom item "turtle:chorium_cluster") at (victim ~ vector(0.5,0.5,0.5))
+    drop 1 of (custom item "turtle:chorium_cluster") at (victim ~ vector(0.5,0.5,0.5))

--- a/scripts/items/custom/blazing_pickaxe.sk
+++ b/scripts/items/custom/blazing_pickaxe.sk
@@ -22,6 +22,10 @@ when ready to register custom items:
                 blocks: minecraft block tag "mineable/pickaxe"
                 speed: 8
                 correct_for_drops: true
+            apply tool rule:
+                blocks: minecraft block tag "mineable/hoe"
+                speed: 8
+                correct_for_drops: true
     set (max durability of (custom item "turtle:blazing_paxel")) to 1000
     make (custom item "turtle:blazing_paxel") fire resistant
 
@@ -44,13 +48,17 @@ when ready to load recipes:
             set ingredient of "i" to (custom item "turtle:blazing_ingot")
             set ingredient of "h" to (custom item "turtle:reinforced_handle")
 
+on damage:
+    (item id of attacker's tool) is "turtle:blazing_pickaxe" or "turtle:blazing_paxel"
+    ignite victim for 4 seconds
+
 on break:
     gamemode of player isn't creative
-    ("turtle:blazing_pickaxe", "turtle:blazing_paxel") contains (item id of player's tool)
+    (item id of player's tool) is "turtle:blazing_pickaxe" or "turtle:blazing_paxel"
     inventory of event-block isn't set
     # smelt drops
     clear drops
     loop drops of event-block using player's tool as player:
-        drop smelted loop-value at event-block's location ~ vector(0.5,0.5,0.5)
-        if smelted loop-value isn't loop-value:
+        drop ((smelted loop-value) ? loop-value) at (event-block's location) ~ vector(0.5,0.5,0.5)
+        if ((smelted loop-value) ? loop-value) isn't loop-value:
             draw 5 of flame at event-block with extra 0.05

--- a/scripts/items/custom/diamond_paxel.sk
+++ b/scripts/items/custom/diamond_paxel.sk
@@ -18,6 +18,10 @@ when ready to register custom items:
                 blocks: minecraft block tag "mineable/pickaxe"
                 speed: 8
                 correct_for_drops: true
+            apply tool rule:
+                blocks: minecraft block tag "mineable/hoe"
+                speed: 8
+                correct_for_drops: true
 
 when ready to load recipes:
     register shaped recipe:

--- a/scripts/items/vanilla/food.sk
+++ b/scripts/items/vanilla/food.sk
@@ -1,0 +1,38 @@
+
+when ready to register custom items:
+    # sugar
+    set (custom item "minecraft:sugar") to sugar
+    apply food component to (custom item "minecraft:sugar"):
+        nutrition: 1
+        saturation: 0.6
+        can_always_eat: true
+    apply consumable component to (custom item "minecraft:sugar"):
+        consume_seconds: 0.8 seconds
+        on_consume_effect: apply_effects(potion effect of speed for 10 seconds, 1/3)
+    # resin clump
+    set (custom item "minecraft:resin_clump") to resin clump
+    apply food component to (custom item "minecraft:resin_clump"):
+        nutrition: 1
+        saturation: 0.6
+        can_always_eat: true
+    apply consumable component to (custom item "minecraft:resin_clump"):
+        consume_seconds: 0.8 seconds
+    # nether wart
+    set (custom item "minecraft:nether_wart") to nether wart
+    apply food component to (custom item "minecraft:nether_wart"):
+        nutrition: 3
+        saturation: 1.2
+        can_always_eat: true
+    apply consumable component to (custom item "minecraft:nether_wart"):
+        consume_seconds: 0.8 seconds
+        on_consume_effect: apply_effects(potion effect of nausea for 15 seconds, 0.2)
+    # cookie
+    set (custom item "minecraft:cookie") to cookie
+    apply consumable component to (custom item "minecraft:cookie"):
+        consume_seconds: 1.2 seconds
+    # dried kelp
+    set (custom item "minecraft:dried_kelp") to dried kelp
+    apply food component to (custom item "minecraft:dried_kelp"):
+        nutrition: 1
+        saturation: 0.6
+        can_always_eat: true

--- a/scripts/server/player.sk
+++ b/scripts/server/player.sk
@@ -66,6 +66,10 @@ every tick:
 
 # handle player death
 on death of player:
+    # phantom
+    if (environment of event-world) is end:
+        spawn phantom at victim
+    # drops
     set {_e} to enchantment from key "turtle:soulbound"
     event.getKeepInventory() is false
     set {_drops::*} to ...event.getDrops()
@@ -76,13 +80,14 @@ on death of player:
     # cookie
     if (lowercase name of victim) contains "cookie":
         add cookie to {_drops::*}
+    set {_protectDeathLoot} to getConfigValue("root.players.protectDeathLoot")
     loop {_drops::*}:
         # soulbound
         if loop-value is enchanted with {_e}:
             event.getItemsToKeep().add(loop-value)
         # protected items
         else:
-            if getConfigValue("root.players.protectDeathLoot") is true:
+            if {_protectDeathLoot} is true:
                 event.getDrops().add(protectItemStack(loop-value))
             else:
                 event.getDrops().add(loop-value)


### PR DESCRIPTION
- Make nether wart, resin clump, and sugar edible. Change cookie and dried kelp
- Paxels can mine all hoeable blocks
- Shulkers from ender vaults now only drop 1 chorium cluster
- Wardens drop echo shards
- Players dying in the end spawns a phantom