### PR TITLE
Change chorium elytra ability, Processing recipe tweaks

### DIFF
--- a/config.sk
+++ b/config.sk
@@ -337,7 +337,7 @@ databases:
 		
 		backup interval: 0 hours
 		# Creates a backup of the file every so often. This can be useful if you ever want to revert variables to an older state.
-		# Variables are saved constantly no matter what is set here, thus a server crash will never make you loose any variables.
+		# Variables are saved constantly no matter what is set here, thus a server crash will never make you lose any variables.
 		# Set this to 0 to disable this feature.
 		
 		# WARNING: Setting to 0 will delete all files located in the backup directory upon plugin start/reload
@@ -385,7 +385,7 @@ databases:
 	default:
 		# The default "database" is a simple text file, with each variable on a separate line and the variable's name, type, and value separated by commas.
 		# This is the last database in this list to catch all variables that have not been saved anywhere else.
-		# You can modify this database freely, but make sure to know what you're doing if you don't want to loose any variables.
+		# You can modify this database freely, but make sure to know what you're doing if you don't want to lose any variables.
 		
 		type: CSV
 		
@@ -405,7 +405,7 @@ databases:
 		
 		# ==== Settings that should not be changed ====
 		
-version: 2.12.0
+version: 2.12.1
 # DO NOT CHANGE THIS VALUE MANUALLY!
 # This saves for which version of Skript this configuration was written for.
 # If it does not match the version of the .jar file then the config will be updated automatically.

--- a/scripts/_utils/utils/directions.sk
+++ b/scripts/_utils/utils/directions.sk
@@ -10,6 +10,7 @@ expression:
 
 # Facing of vector
 # Get the cardinal direction of a vector
+# TODO: support up/down, specify with 'horizontal' in pattern
 expression:
     patterns:
         [the] facing of [vector] %vector%
@@ -34,7 +35,6 @@ expression:
 # Get a vector from a cardinal direction
 expression:
     patterns:
-        [the] vector of [direction] %direction%
-        [direction] %direction%'[s] vector
+        [the] vector (of|from) dir[ection] %direction%
     get:
         return expr-1.getDirection()

--- a/scripts/_utils/utils/format.sk
+++ b/scripts/_utils/utils/format.sk
@@ -1,0 +1,18 @@
+
+function formatLocation(loc:location, includeWorld:boolean=true, includeRotation:boolean=false) :: string:
+    if {_loc} isn't set:
+        return {_}
+    set {_str} to "%x-coord of {_loc}%,%y-coord of {_loc}%,%z-coord of {_loc}%"
+    if {_includeWorld} is true:
+        add ",w:%world of {_loc}%" to {_str}
+    if {_includeRotation} is true:
+        add ",r:%yaw of {_loc}%,%pitch of {_loc}%" to {_str}
+    return {_str}
+
+function formatVector(v:vector, includeY:boolean=true) :: string:
+    if {_v} isn't set:
+        return {_}
+    if {_includeY} is true:
+        return "%x of {_v}%,%y of {_v}%,%z of {_v}%"
+    else:
+        return "%x of {_v}%,%z of {_v}%"

--- a/scripts/_utils/utils/random.sk
+++ b/scripts/_utils/utils/random.sk
@@ -1,10 +1,86 @@
 
-# Random of world
+import:
+    java.util.Random
+    java.util.Arrays
+    java.util.Collections
+
+# Get a random seed
 expression:
     patterns:
-        [next] random [float|num[ber]] (of|from) %world%
-        %world%'s [next] random [float|num[ber]]
+        [a] random[ized] seed
     get:
-        if expr-1 isn't set:
-            return 0
-        return expr-1.getHandle().getRandom().nextFloat()
+        return new Random().nextLong()
+
+# Get a new Random instance
+expression:
+    patterns:
+        [a] [new] random instance [(with seed|using) %-integer%]
+    get:
+        if expr-1 is set:
+            return new Random(expr-1)
+        else:
+            return new Random()
+
+# Random number using seed
+expression:
+    patterns:
+        [a|next] random (:integer|number) (from|between) %number% (to|and) %number% (with|of|from|using) [random] [instance] %javaobject%
+    get:
+        set {_isInteger} to (true if (parse tags contains "integer") else false)
+        set {_min} to expr-1
+        set {_max} to expr-2
+        set {_random} to expr-3
+        {_random} is instance of Random
+        if {_isInteger} is true:
+            return {_random}.longs({_min}, {_max}+1).findFirst().orElse({_min})
+        else:
+            return {_min} + {_random}.nextDouble() * ({_max}-{_min})
+
+# Random element of objects using seed
+expression:
+    patterns:
+        [a] random element [out] of %objects% (with|of|from|using) [random] [instance] %javaobject%
+    get:
+        set {_items::*} to expr-1
+        set {_random} to expr-2
+        return {_items::%{_random}.nextInt(size of {_items::*})+1%}
+
+# Shuffle using seed
+plural expression:
+    patterns:
+        shuffled %objects% (with|of|from|using) [random] [instance] %javaobject%
+    get:
+        if size of exprs-1 is 0:
+            return
+        expr-2 is instance of Random
+        set {_list} to Arrays.asList([expr-1])
+        Collections.shuffle({_list}, expr-2)
+        return ...{_list}
+
+# Weighted shuffle, optionally with seed
+plural expression:
+    patterns:
+        shuffled %objects% (with|using) weights %numbers% [(with|of|from|using) [random] [instance] %-javaobject%]
+    get:
+        set {_items::*} to expr-1
+        set {_weights::*} to expr-2
+        set {_random} to expr-3 ? (new random instance)
+        if (size of {_items::*}) isn't (size of {_weights::*}):
+            return
+        loop {_weights::*}:
+            if loop-value isn't a number:
+                return
+            add loop-value to {_totalWeight}
+        loop (size of {_items::*}) times:
+            set {_r} to {_random}.nextDouble() * {_totalWeight}
+            set {_accum} to 0
+            loop {_weights::*}:
+                add loop-value-2 to {_accum}
+                if {_r} <= {_accum}:
+                    remove loop-value-2 from {_totalWeight}
+                    add {_items::%loop-iteration-2%} to {_result::*}
+                    delete {_items::%loop-iteration-2%}
+                    set {_items::*} to {_items::*}
+                    delete {_weights::%loop-iteration-2%}
+                    continue 1st loop
+        return {_result::*}

--- a/scripts/_utils/utils/simple.sk
+++ b/scripts/_utils/utils/simple.sk
@@ -1,16 +1,12 @@
 
 # Pass
-# Does nothing, useful for placeholders.
+# Does nothing.
 effect:
     patterns:
         pass
         do nothing
     trigger:
         exit
-
-expression colon:
-    get:
-        return ":"
 
 function str(val:object) :: string:
     return "%{_val}%"

--- a/scripts/chat/commands/color.sk
+++ b/scripts/chat/commands/color.sk
@@ -6,7 +6,7 @@ on load:
     set {-chatColors::lime} to rgb(100, 230, 50)
     set {-chatColors::cyan} to rgb(0, 180, 200)
     set {-chatColors::blue} to rgb(60, 120, 255)
-    set {-chatColors::purple} to rgb(160, 80, 255)
+    set {-chatColors::purple} to rgb(130, 70, 255)
     set {-chatColors::magenta} to rgb(240, 50, 200)
     set {-chatColors::pink} to rgb(255, 150, 200)
     set {-chatColors::white} to rgb(255, 255, 255)
@@ -14,7 +14,7 @@ on load:
 
 brig command /turtle:color:
     arguments:
-        register literal arg "color" using ("reset","red","orange","yellow","lime","aqua","blue","purple","magenta","pink","white","black")
+        register literal arg "color" using ("reset","red","orange","yellow","lime","cyan","blue","purple","magenta","pink","white","black")
     trigger:
         if {_color} is "reset":
             delete {PlayerData::%player%::chatColor}

--- a/scripts/enchantments/soulbound.sk
+++ b/scripts/enchantments/soulbound.sk
@@ -5,4 +5,4 @@ on drop:
     event-item is enchanted with {_e}
     cancel event
     send actionbar "§cSneak to drop a soulbound item"
-    play sound "minecraft:block.note_block.hat" with volume 0.25 to player
+    play sound "minecraft:block.note_block.hat" in (ui) with volume 0.25 to player

--- a/scripts/items/custom/chorium_elytra.sk
+++ b/scripts/items/custom/chorium_elytra.sk
@@ -20,20 +20,23 @@ on toggle gliding:
     wait 1 tick
     while player is gliding:
         wait 1 tick
-        item id of (player's chestplate) is "turtle:chorium_elytra"
-        set {_speed} to (vector length of (player's velocity))
-        {_speed} > 0.8
-        set {_loc} to (location 1 block in front of player)
-        set {_loc} to {_loc} ~ vector(0,0.5,0)
-        set {_leftwing} to (location 1.25 blocks left of {_loc})
-        set {_rightwing} to (location 1.25 blocks right of {_loc})
-        make 1 of witch at {_leftwing} with extra 0 with force
-        make 1 of witch at {_rightwing} with extra 0 with force
-        set {_e::*} to (entities in radius 2.5 of (location 0.5 blocks under player))
-        set {_e::*} to ({_e::*} where [input isn't player])
-        set {_source} to (damage source of player attack caused by player directly by player at player)
-        damage {_e::*} by (3.5*{_speed}) with {_source}
-        loop {_e::*}:
-            push loop-value (player's velocity) with force (1-(knockback resistance attribute of loop-value))
-            if loop-value is ("end crystal" parsed as entity type):
-                make player attack loop-value
+        (item id of (player's chestplate)) is "turtle:chorium_elytra"
+        player is pressing sneak key
+        apply slow falling without particles without the icon to (player) for (5 ticks) replacing existing effect
+        chance of 0.25
+        make 1 of poof at player with extra 0.1
+
+on press of jump key:
+    player is gliding
+    player isn't pressing sneak key
+    y of (velocity of player) <= 0
+    (item id of (player's chestplate)) is "turtle:chorium_elytra"
+    if player's gamemode isn't creative:
+        loop 6 times:
+            (durability of player's chestplate) > 1
+            player.damageItemStack(chest slot, 1)
+    make 1 explosion at player
+    loop 10 times:
+        push player up with speed 0.1
+        make 1 witch at player with extra 0.25
+        wait 1 tick

--- a/scripts/items/custom/chorium_mirror.sk
+++ b/scripts/items/custom/chorium_mirror.sk
@@ -53,8 +53,11 @@ local function updateItem(item:item) :: item:
 local function getMirrorLoc(mirrorLoc:nbtcompound) :: location:
     {_mirrorLoc} is set
     set {_pos::*} to (int array tag "pos" of {_mirrorLoc})
-    set {_world} to (world from key (string tag "dimension" of {_mirrorLoc}))
-    set {_loc} to location(1st element of {_pos::*},2st element of {_pos::*},3st element of {_pos::*},{_world})
+    set {_world} to (world (string tag "world" of {_mirrorLoc})) ? (world from key (string tag "dimension" of {_mirrorLoc}))
+    set {_x} to (1st element of {_pos::*})
+    set {_y} to (2nd element of {_pos::*})
+    set {_z} to (3rd element of {_pos::*})
+    set {_loc} to location({_x},{_y},{_z},{_world})
     return {_loc}
 
 local function mirrorTp(p:player,loc:location):
@@ -74,14 +77,14 @@ on custom item interact with "turtle:chorium_mirror":
     set {_mirror} to (player's offhand tool) if (event-equipmentslot is off hand slot) else (player's tool)
     if durability of {_mirror} <= 1:
         play sound "minecraft:item.ominous_bottle.dispose" in player category at player
-        exit
+        exit trigger
     set {_mirrorLoc} to (compound tag "mirrorLoc" of (custom nbt of {_mirror}))
     if ({_mirrorLoc} ? empty nbt compound) is (empty nbt compound):
         # bind location
         set {_mirrorLoc} to (empty nbt compound)
         set {_loc} to (player's location)
         set (int array tag "pos" of {_mirrorLoc}) to (floor(x-coord of {_loc}),floor(y-coord of {_loc}),floor(z-coord of {_loc}))
-        set (string tag "dimension" of {_mirrorLoc}) to "%event-world.getKey()%"
+        set (string tag "world" of {_mirrorLoc}) to "%event-world%"
         set (compound tag "mirrorLoc" of (custom nbt of {_mirror})) to {_mirrorLoc}
         set (boolean tag "hasMirrorLoc" of (custom nbt of {_mirror})) to true
         play sound "minecraft:entity.illusioner.prepare_mirror" in player category at player

--- a/scripts/items/vanilla/flint_and_steel.sk
+++ b/scripts/items/vanilla/flint_and_steel.sk
@@ -15,7 +15,7 @@ on right click with flint and steel:
     {_e} isn't ignited
     cancel event
     ignite {_e}
-    play sound "minecraft:item.flintandsteel.use" in blocks category with volume 1 with pitch ((random of (world of {_e}))*0.4+0.8) at {_e}
+    play sound "minecraft:item.flintandsteel.use" in (blocks category) at ({_e}'s location)
     make player swing their hand
     player's gamemode isn't creative
     player.damageItemStack(hand slot, 1)

--- a/scripts/processing/cauldron-recipes.sk
+++ b/scripts/processing/cauldron-recipes.sk
@@ -40,7 +40,7 @@ when ready to load recipes:
     addSimpleCauldronRecipe("washing", "turtle:crushed_raw_copper", (getSimpleResult(custom item "turtle:copper_nugget", 9), getSimpleResult(clay_ball, 1, 0.5)))
     addSimpleCauldronRecipe("washing", "minecraft:gravel", (getSimpleResult(flint, 1, 0.25), getSimpleResult(iron nugget, 1, 0.12)))
     addSimpleCauldronRecipe("washing", "minecraft:ice", getSimpleResult(packed ice))
-    addSimpleCauldronRecipe("washing", "minecraft:magma_block", getSimpleResult(obsidian))
+    addSimpleCauldronRecipe("washing", "minecraft:magma_block", getSimpleResult(stone))
     addSimpleCauldronRecipe("washing", "minecraft:sand", getSimpleResult(clay ball, 1, 0.25))
     addSimpleCauldronRecipe("washing", "minecraft:red_sand", (getSimpleResult(gold nugget, 3, 0.12), getSimpleResult(dead bush, 1, 0.05)))
     addSimpleCauldronRecipe("washing", "minecraft:soul_sand", (getSimpleResult(quartz, 4, 0.12), getSimpleResult(gold nugget, 1, 0.02)))

--- a/scripts/processing/cauldrons.sk
+++ b/scripts/processing/cauldrons.sk
@@ -31,8 +31,8 @@ local function dropOrHopper(items:items, hoppers:blocks, loc:location):
                 (inventory of loop-value-1) has space for loop-value-2
                 checkHopperFilter(loop-value-2, loop-value-1) is false
             then:
-                add loop-value-2 to inventory of loop-value-1
-                remove loop-value-2 from {_items::*}
+                add (loop-value-2) to (inventory of (loop-value-1))
+                remove (loop-value-2) from {_items::*}
     drop {_items::*} at {_loc} without velocity
 
 on entity inside block:

--- a/scripts/processing/pressing-recipes.sk
+++ b/scripts/processing/pressing-recipes.sk
@@ -47,6 +47,8 @@ when ready to load recipes:
     addPressingRecipe("minecraft:large_fern", (getSimpleResult(green_dye, 2), getSimpleResult(green_dye, 1, 0.5), getSimpleResult(wheat_seeds, 1, 0.1)))
     addPressingRecipe("minecraft:grass", getSimpleResult(wheat_seeds, 1, 0.25))
     addPressingRecipe("minecraft:tall_grass", getSimpleResult(wheat_seeds, 1, 0.5))
+    addPressingRecipe("minecraft:stone", getSimpleResult(cobblestone))
+    addPressingRecipe("minecraft:deepslate", getSimpleResult(cobbled deepslate))
     addPressingRecipe("minecraft:cobblestone", getSimpleResult(gravel))
     addPressingRecipe("minecraft:gravel", (getSimpleResult(sand), getSimpleResult(flint, 1, 0.1), getSimpleResult(clay_ball, 1, 0.05)))
     addPressingRecipe("minecraft:sandstone", getSimpleResult(sand))

--- a/scripts/processing/pressing.sk
+++ b/scripts/processing/pressing.sk
@@ -21,7 +21,7 @@ local function getCompactedItem(item:itemtype,amount:integer) :: objects:
 on entity change block:
     event-entity is falling block
     (block tag "minecraft:anvil") contains event-blockdata
-    pressProcessBlock(event-block, vector of down)
+    pressProcessBlock(event-block, vector of dir down)
 
 # piston crush items
 on piston extend:

--- a/scripts/server/player.sk
+++ b/scripts/server/player.sk
@@ -32,7 +32,7 @@ local function getAfkNameColor(p:player, base:color) :: color:
     set {_end} to 90*20
     set {_x} to (1-(({_s}-{_start})/({_end}-{_start}))*(1-{_min}))
     set {_x} to clamp({_x},{_min},1)
-    return rgb({_r}*{_x},{_g}*{_x},{_b}*{_x})
+    return rgb(({_r}*{_x}),({_g}*{_x}),({_b}*{_x}))
 
 every tick:
     # vars

--- a/scripts/server/server.sk
+++ b/scripts/server/server.sk
@@ -6,9 +6,8 @@ options:
 
 # gamerules
 on load:
-    loop all worlds:
-        set gamerule playersSleepingPercentage of loop-world to 0
-        set gamerule doInsomnia of loop-world to false
+    set gamerule playersSleepingPercentage of (world "world") to 0
+    set gamerule doInsomnia of (world "world") to false
 
 function findResourcePackHash():
     log info "Fetching resource pack hash from {@resourcePackUrl}§r..."

--- a/scripts/stuff/voidwrap.sk
+++ b/scripts/stuff/voidwrap.sk
@@ -23,14 +23,15 @@ local function warp(e:entity, world:text, coord:number):
 
 on entity remove from world:
     str(event-entityremovecause) is "out_of_world"
-    (environment of event-world) is end
+    event-world is (world {@endWorld})
     voidProcess(event-entity)
     warp(event-entity, {@overworld}, {@upWrapY})
 
 on damage:
     damage cause is void
-    cancel event
-    (environment of event-world) is end
+    if (gamerule keepInventory of event-world) isn't true:
+        cancel event
+    event-world is (world {@endWorld})
     warp(victim, {@overworld}, {@upWrapY})
     while (y-coord of victim) > ({@upWrapY}-10):
         push victim down with force 0.25


### PR DESCRIPTION
- Remove chorium elytra doing fly-by damage
- Hold shift while gliding with chorium elytra to descent slowly
- Push jump while descending and gliding to get a small upwards boost, at the cost of durability
- Tweak processing recipes: washing magma block gives stone instead of obsidian, press stone/deepslate to cobbled stone/deepslate
- Misc changes and setup for dungeons